### PR TITLE
fix indentation error in spliceOut method of BinarySearchTree

### DIFF
--- a/Trees/.ipynb_checkpoints/Binary Search Trees-checkpoint.ipynb
+++ b/Trees/.ipynb_checkpoints/Binary Search Trees-checkpoint.ipynb
@@ -17,9 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class TreeNode:\n",
@@ -168,14 +166,14 @@
     "                    \n",
     "                    self.parent.rightChild = self.leftChild\n",
     "                    self.leftChild.parent = self.parent\n",
-    "        else:\n",
-    "                    \n",
-    "            if self.isLeftChild():\n",
-    "                        \n",
-    "                self.parent.leftChild = self.rightChild\n",
     "            else:\n",
-    "                self.parent.rightChild = self.rightChild\n",
-    "                self.rightChild.parent = self.parent\n",
+    "\n",
+    "                if self.isLeftChild():\n",
+    "\n",
+    "                    self.parent.leftChild = self.rightChild\n",
+    "                else:\n",
+    "                    self.parent.rightChild = self.rightChild\n",
+    "                    self.rightChild.parent = self.parent\n",
     "\n",
     "    def findSuccessor(self):\n",
     "        \n",
@@ -249,9 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -283,23 +279,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/Trees/Binary Search Trees.ipynb
+++ b/Trees/Binary Search Trees.ipynb
@@ -17,9 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class TreeNode:\n",
@@ -168,14 +166,14 @@
     "                    \n",
     "                    self.parent.rightChild = self.leftChild\n",
     "                    self.leftChild.parent = self.parent\n",
-    "        else:\n",
-    "                    \n",
-    "            if self.isLeftChild():\n",
-    "                        \n",
-    "                self.parent.leftChild = self.rightChild\n",
     "            else:\n",
-    "                self.parent.rightChild = self.rightChild\n",
-    "                self.rightChild.parent = self.parent\n",
+    "\n",
+    "                if self.isLeftChild():\n",
+    "\n",
+    "                    self.parent.leftChild = self.rightChild\n",
+    "                else:\n",
+    "                    self.parent.rightChild = self.rightChild\n",
+    "                    self.rightChild.parent = self.parent\n",
     "\n",
     "    def findSuccessor(self):\n",
     "        \n",
@@ -249,9 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -283,23 +279,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Please be aware that I fixed the indentation using the Jupyter notebook which affected other metadata including the Python version as I am using Python 3.