### PR TITLE
anagram2 function has a minor bug

### DIFF
--- a/Array Sequences/Array Sequences Interview Questions/Array Sequence Interview Questions - SOLUTIONS/Anagram Check - SOLUTION.ipynb
+++ b/Array Sequences/Array Sequences Interview Questions/Array Sequence Interview Questions - SOLUTIONS/Anagram Check - SOLUTION.ipynb
@@ -141,7 +141,7 @@
     "        if letter in count:\n",
     "            count[letter] -= 1\n",
     "        else:\n",
-    "            count[letter] = 1\n",
+    "            count[letter] = -1\n",
     "    \n",
     "    # Check that all counts are 0\n",
     "    for k in count:\n",


### PR DESCRIPTION
Due to how the checks are made it's not exposed, but it's not following the logic. Walking though the s2 string is supposed to subtract the letters from the dict, if the letter is not on the dict we should set the value to -1 not 1. See the values on the dict at the end of a run of anagram2('dogbb','godbbcc') whithout fixing:
d 0
o 0
g 0
b 0
c 0
With the fix:
d 0
o 0
g 0
b 0
c -2
Due to the check returning False if len s1 != s2 this bug does not make the whole def fail, but I think it should be fixed with the proper logic.